### PR TITLE
Single study place enforcement notice test and UI messages

### DIFF
--- a/src/main/resources/translations/en.json
+++ b/src/main/resources/translations/en.json
@@ -83,6 +83,11 @@
     "acceptEducation": {
       "received": "Study place granted",
       "latestAnswer": "Submit your answer by __aika__, or you will lose the offered study place.",
+      "onlyOnePossible": {
+        "1": "You may accept",
+        "2": "only one",
+        "3": "study place leading to a higher education degree in Finland during one academic term."
+      },
       "accept": "I confirm the granted study place",
       "conditionalAccept": "I confirm the study place conditionally",
       "conditionalAcceptInfo1": "You can still get accepted from a waiting list to a higher prioritized study programme.",

--- a/src/main/resources/translations/fi.json
+++ b/src/main/resources/translations/fi.json
@@ -83,6 +83,11 @@
     "acceptEducation": {
       "received": "Opiskelupaikka myönnetty",
       "latestAnswer": "Lähetä vastauksesi __aika__ mennessä tai menetät tarjotun opiskelupaikan.",
+      "onlyOnePossible": {
+        "1": "Voit ottaa vastaan samana lukukautena alkavasta koulutuksesta",
+        "2": "vain yhden",
+        "3": "korkeakoulututkintoon johtavan opiskelupaikan."
+      },
       "accept": "Otan opiskelupaikan vastaan sitovasti",
       "conditionalAccept": "Otan opiskelupaikan vastaan ehdollisesti",
       "conditionalAcceptInfo1": "Voit edelleen tulla varasijalta hyväksytyksi mieluisampaan hakutoiveeseen.",

--- a/src/main/resources/translations/sv.json
+++ b/src/main/resources/translations/sv.json
@@ -83,6 +83,11 @@
     "acceptEducation": {
       "received": "Studieplats beviljad",
       "latestAnswer": "Skicka svaret före __aika__, annars går du miste om den erbjudna studieplatsen.",
+      "onlyOnePossible": {
+        "1": "Du kan ta emot",
+        "2": "endast en",
+        "3": "studieplats som leder till högskoleexamen i utbildning som börjar inom samma termin."
+      },
       "accept": "Jag tar emot den beviljade studieplatsen",
       "conditionalAccept": "Jag tar emot studieplatsen villkorligt",
       "conditionalAcceptInfo1": "Du kan fortfarande bli godkänd från reservplats till ett ansökningsönskemål med högre prioritet.",

--- a/src/main/webapp/test/page/applicationListPage.js
+++ b/src/main/webapp/test/page/applicationListPage.js
@@ -270,6 +270,12 @@ function ApplicationListPage() {
             }).toArray()
           },
 
+          singleStudyPlaceEnforcement: function() {
+            return vastaanottoElement().find("[ng-if='haku().showSingleStudyPlaceEnforcement']").map(function() {
+              return $(this).text().trim()
+            }).toArray()
+          },
+
           vaihtoehdot: function() {
             return vastaanottoElement().find(".hakutoive-options label:visible").map(function() {
               return $(this).text().trim()

--- a/src/main/webapp/test/spec/applicationListSpec.js
+++ b/src/main/webapp/test/spec/applicationListSpec.js
@@ -162,7 +162,7 @@
 
       it('ensimmäisenä on uusin hakemus', function () {
         expect(ApplicationListPage().applications()[0]).to.deep.equal(
-          { applicationSystemName: 'Korkeakoulujen yhteishaku syksy 2016' }
+          { applicationSystemName: 'Haku ammatilliseen erityisopettajankoulutukseen 2016' }
         )
       })
 

--- a/src/main/webapp/test/spec/applicationListSpec.js
+++ b/src/main/webapp/test/spec/applicationListSpec.js
@@ -761,6 +761,14 @@
             ])
           })
 
+          it("varoitus yhden paikan säännöstä näkyy", function() {
+            var singleStudyPlaceEnforcement = hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).singleStudyPlaceEnforcement()
+            expect(singleStudyPlaceEnforcement).to.have.length(1)
+            expect(singleStudyPlaceEnforcement[0]).to.have.string("Voit ottaa vastaan samana lukukautena alkavasta koulutuksesta")
+            expect(singleStudyPlaceEnforcement[0]).to.have.string("vain yhden")
+            expect(singleStudyPlaceEnforcement[0]).to.have.string("korkeakoulututkintoon johtavan opiskelupaikan.")
+          })
+
           describe("paikan vastaanottaminen sitovasti", function() {
             before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectOption("VASTAANOTTANUT"))
             before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).send)

--- a/src/main/webapp/test/spec/applicationListSpec.js
+++ b/src/main/webapp/test/spec/applicationListSpec.js
@@ -745,10 +745,11 @@
         })
 
         describe("kk haussa, kun ylempi toive on varalla ja alempi hyväksytty", function() {
-          before(page.applyValintatulosFixtureAndOpen("vastaanotettavissa-ehdollisesti"))
+          before(page.applyValintatulosFixtureAndOpen("korkeakoulu-vastaanotettavissa-ehdollisesti", {"haku": "korkeakoulu-yhteishaku-kevat2015"}),
+            page.applyFixtureAndOpen({applicationOid: hakemusKorkeakouluKevatId}))
 
           it("voi ottaa myös ehdollisesti vastaan", function() {
-            expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).vaihtoehdot()).to.deep.equal([
+            expect(hakemusKorkeakouluKevat.vastaanotto(0).vaihtoehdot()).to.deep.equal([
                   'Otan opiskelupaikan vastaan sitovasti',
                   'Otan opiskelupaikan vastaan ehdollisesti',
                   'En ota opiskelupaikkaa vastaan'
@@ -756,13 +757,13 @@
           })
 
           it("vastausaika näkyy", function() {
-            expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).info()).to.deep.equal([
+            expect(hakemusKorkeakouluKevat.vastaanotto(0).info()).to.deep.equal([
                   "Lähetä vastauksesi 10. tammikuuta 2100 klo 12.00 mennessä tai menetät tarjotun opiskelupaikan."
             ])
           })
 
           it("varoitus yhden paikan säännöstä näkyy", function() {
-            var singleStudyPlaceEnforcement = hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).singleStudyPlaceEnforcement()
+            var singleStudyPlaceEnforcement = hakemusKorkeakouluKevat.vastaanotto(0).singleStudyPlaceEnforcement()
             expect(singleStudyPlaceEnforcement).to.have.length(1)
             expect(singleStudyPlaceEnforcement[0]).to.have.string("Voit ottaa vastaan samana lukukautena alkavasta koulutuksesta")
             expect(singleStudyPlaceEnforcement[0]).to.have.string("vain yhden")
@@ -770,41 +771,42 @@
           })
 
           describe("paikan vastaanottaminen sitovasti", function() {
-            before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectOption("VASTAANOTTANUT"))
-            before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).send)
+            before(hakemusKorkeakouluKevat.vastaanotto(0).selectOption("VASTAANOTTANUT"))
+            before(hakemusKorkeakouluKevat.vastaanotto(0).send)
 
             it("vastaanottotieto näkyy", function() {
-              expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.valintatulokset()[0].tila).to.equal('Peruuntunut')
-              expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.valintatulokset()[1].tila).to.equal('Opiskelupaikka vastaanotettu')
+              expect(hakemusKorkeakouluKevat.valintatulokset()[0].tila).to.equal('Peruuntunut')
+              expect(hakemusKorkeakouluKevat.valintatulokset()[1].tila).to.equal('Opiskelupaikka vastaanotettu')
             })
           })
 
           describe("paikan vastaanottaminen ehdollisesti", function() {
-            before(page.applyValintatulosFixtureAndOpen("vastaanotettavissa-ehdollisesti"))
-            before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectOption("EHDOLLISESTI_VASTAANOTTANUT"))
-            before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).send)
+            before(page.applyValintatulosFixtureAndOpen("korkeakoulu-vastaanotettavissa-ehdollisesti"))
+            before(hakemusKorkeakouluKevat.vastaanotto(0).selectOption("EHDOLLISESTI_VASTAANOTTANUT"))
+            before(hakemusKorkeakouluKevat.vastaanotto(0).send)
 
             it("vastaanottotieto näkyy", function() {
-              expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.valintatulokset()[0].tila).to.equal('1. varasijalla')
-              expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.valintatulokset()[1].tila).to.equal('Opiskelupaikka vastaanotettu ehdollisesti')
+              expect(hakemusKorkeakouluKevat.valintatulokset()[0].tila).to.equal('1. varasijalla')
+              expect(hakemusKorkeakouluKevat.valintatulokset()[1].tila).to.equal('Opiskelupaikka vastaanotettu ehdollisesti')
             })
           })
 
           describe("paikan hylkääminen", function() {
-            before(page.applyValintatulosFixtureAndOpen("vastaanotettavissa-ehdollisesti"))
-            before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectOption("PERUNUT"))
-            before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).send)
+            before(page.applyValintatulosFixtureAndOpen("korkeakoulu-vastaanotettavissa-ehdollisesti"))
+            before(hakemusKorkeakouluKevat.vastaanotto(0).selectOption("PERUNUT"))
+            before(hakemusKorkeakouluKevat.vastaanotto(0).send)
 
             it("perumistieto näkyy", function() {
-              expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.valintatulokset()[0].tila).to.equal('1. varasijalla')
-              expect(hakemusYhteishakuKevat2013WithForeignBaseEducation.valintatulokset()[1].tila).to.equal('Peruit opiskelupaikan')
+              expect(hakemusKorkeakouluKevat.valintatulokset()[0].tila).to.equal('1. varasijalla')
+              expect(hakemusKorkeakouluKevat.valintatulokset()[1].tila).to.equal('Peruit opiskelupaikan')
             })
           })
         })
       })
 
-      describe("kun hakijalle tarjotaan kahta paikkaa kk varsinaisessa haussa (virhetilanne, mutta vastaa lisähaun toimintaa)", function() {
-        before(page.applyValintatulosFixtureAndOpen("hyvaksytty-kaikkiin"))
+      describe("kun hakijalle tarjotaan kahta paikkaa kk varsinaisessa haussa, virhetilanne, mutta vastaa lisähaun toimintaa", function() {
+        before(page.applyFixtureAndOpen({applicationOid: hakemusYhteishakuKevat2013WithForeignBaseEducationId}),
+          page.applyValintatulosFixtureAndOpen("hyvaksytty-kaikkiin", {"haku": "korkeakoulu-yhteishaku"}))
 
         describe("alkutilassa", function() {
           it("oikeat vaihtoehdot tulevat näkyviin", function() {


### PR DESCRIPTION
Test requires new test data in
- [valinta-tulos-service](https://github.com/Opetushallitus/valinta-tulos-service/commit/a4cb2fa73127ce0417b427b4a37f05ee4428a07c)
- [haku](https://github.com/Opetushallitus/haku/pull/16)
- [hakemuseditori](https://github.com/Opetushallitus/hakemuseditori/pull/1) which also contains the implementation of the feature.