### PR TITLE
Bug 1737 parempi logitus jatkoa varten

### DIFF
--- a/src/main/scala/fi/vm/sade/hakemuseditori/HakemusEditori.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/HakemusEditori.scala
@@ -87,9 +87,38 @@ trait HakemusEditoriComponent extends ApplicationValidatorComponent
     def fetchByHakemusOid(request: HttpServletRequest,
                           personOid: String,
                           hakemusOid: String,
-                          valintatulosFetchStrategy: ValintatulosFetchStrategy): Option[HakemusInfo] =
-      hakemusRepository.getHakemus(request, hakemusOid, valintatulosFetchStrategy).filter(_.hakemus.personOid == personOid)
-        .orElse(ataruService.findApplications(request, personOid, valintatulosFetchStrategy).find(_.hakemus.oid == hakemusOid))
+                          valintatulosFetchStrategy: ValintatulosFetchStrategy): Option[HakemusInfo] = {
+      val optFromHakemusRepository = hakemusRepository.getHakemus(request, hakemusOid, valintatulosFetchStrategy)
+      if (optFromHakemusRepository.isEmpty) {
+        logger.info("fetchByHakemusOid(): Hakemus repository returned no application for given hakemusOid {}. Searching from ataru.", hakemusOid)
+      }
+
+      val matchingFromHakemusRepository = optFromHakemusRepository.filter { hakemus =>
+        val personOidFromHakemus = hakemus.hakemus.personOid
+        val oidsMatch = personOidFromHakemus == personOid
+        if (!oidsMatch) {
+          logger.warn("fetchByHakemusOid(): Hakemus repository returned an application for hakemusOid {} but its personOid {}" +
+            "did not match the given personOid parameter {}. Searching from ataru.", hakemusOid, personOidFromHakemus, personOid)
+        }
+        oidsMatch
+      }
+
+      val result: Option[HakemusInfo] = matchingFromHakemusRepository.orElse {
+        val ataruApplications = ataruService.findApplications(request, personOid, valintatulosFetchStrategy)
+        val matchingAtaruApplication = ataruApplications.find(_.hakemus.oid == hakemusOid)
+        if (ataruApplications.isEmpty) {
+          logger.warn("fetchByHakemusOid(): Ataru returned no applications for given personOid {}", personOid)
+        } else if (matchingAtaruApplication.isEmpty) {
+          logger.warn("fetchByHakemusOid(): Ataru returned applications for personOid {} but their hakemusOids {}" +
+            "did not match the given hakemusOid {}", ataruApplications.map(_.hakemus.oid), personOid, hakemusOid)
+        }
+        matchingAtaruApplication
+      }
+      if (result.isEmpty){
+          logger.warn("fetchByHakemusOid(): neither hakemus repository nor ataru returned a matching application for personOid {}, hakemusOid {}", personOid, hakemusOid)
+      }
+      result
+    }
 
     def opetuspisteet(asId: String, query: String, lang: Option[String]): Option[List[Opetuspiste]] = koulutusInformaatioService.opetuspisteet(asId, query, parseLang(lang))
 

--- a/src/main/scala/fi/vm/sade/hakemuseditori/HakemusEditori.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/HakemusEditori.scala
@@ -109,13 +109,14 @@ trait HakemusEditoriComponent extends ApplicationValidatorComponent
         if (ataruApplications.isEmpty) {
           logger.warn("fetchByHakemusOid(): Ataru returned no applications for given personOid {}", personOid)
         } else if (matchingAtaruApplication.isEmpty) {
-          logger.warn("fetchByHakemusOid(): Ataru returned applications for personOid {} but their hakemusOids {}" +
-            "did not match the given hakemusOid {}", ataruApplications.map(_.hakemus.oid), personOid, hakemusOid)
+          logger.warn(s"fetchByHakemusOid(): Ataru returned applications for personOid $personOid but " +
+            s"their hakemusOids ${ataruApplications.map(_.hakemus.oid).mkString(",")} did not match the given hakemusOid $hakemusOid")
         }
         matchingAtaruApplication
       }
       if (result.isEmpty){
-          logger.warn("fetchByHakemusOid(): neither hakemus repository nor ataru returned a matching application for personOid {}, hakemusOid {}", personOid, hakemusOid)
+          logger.warn(s"fetchByHakemusOid(): neither hakemus repository nor ataru returned a " +
+            s"matching application for personOid $personOid, hakemusOid $hakemusOid")
       }
       result
     }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/ApplicationsServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/ApplicationsServlet.scala
@@ -135,7 +135,7 @@ trait ApplicationsServletContainer {
           () => Some(hakemus)
         )
         case None =>
-          logger.error("Vastaanotto failed because no application found for: henkiloOid {}, hakemusOid {}", henkiloOid, hakemusOid)
+          logger.error(s"Vastaanotto failed because no application found for: henkiloOid $henkiloOid, hakemusOid $hakemusOid")
           NotFound("error" -> "Not found")
       }
     }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/ApplicationsServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/ApplicationsServlet.scala
@@ -134,7 +134,9 @@ trait ApplicationsServletContainer {
           hakemus.hakemus.email,
           () => Some(hakemus)
         )
-        case None => NotFound("error" -> "Not found")
+        case None =>
+          logger.error("Vastaanotto failed because no application found for: henkiloOid {}, hakemusOid {}", henkiloOid, hakemusOid)
+          NotFound("error" -> "Not found")
       }
     }
   }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/NonSensitiveApplicationServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/NonSensitiveApplicationServlet.scala
@@ -69,6 +69,7 @@ trait VastaanottoEmailContainer {
 
       }
     }
+    logger.info("vastaanota(): henkiloOid {}, hakemusOid {}", henkiloOid, hakemusOid)
     val clientVastaanotto = Serialization.read[ClientSideVastaanotto](requestBody)
     try {
       if (valintatulosService.vastaanota(henkiloOid, hakemusOid, hakukohdeOid, clientVastaanotto.vastaanottoAction)) {
@@ -81,11 +82,14 @@ trait VastaanottoEmailContainer {
         }
         Audit.oppija.log(SaveVastaanotto(request, henkiloOid, hakemusOid, hakukohdeOid, hakuOid, clientVastaanotto.vastaanottoAction))
         fetchHakemus() match {
-          case Some(hakemus) => Ok(hakemus)
-          case _ => NotFound("error" -> "Not found")
+          case Some(hakemus) =>
+            Ok(hakemus)
+          case _ =>
+            logger.error("function type argument fetchHakemus() did not return a Some")
+            NotFound("error" -> "Not found")
         }
-      }
-      else {
+      } else {
+        logger.error("Not receivable: henkiloOid {}, hakemusOid {}, hakukohdeOid {}", henkiloOid, hakemusOid, hakukohdeOid)
         Forbidden("error" -> "Not receivable")
       }
 

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/NonSensitiveApplicationServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/NonSensitiveApplicationServlet.scala
@@ -69,7 +69,7 @@ trait VastaanottoEmailContainer {
 
       }
     }
-    logger.info("vastaanota(): henkiloOid {}, hakemusOid {}", henkiloOid, hakemusOid)
+    logger.info(s"vastaanota(): henkiloOid $henkiloOid, hakemusOid $hakemusOid")
     val clientVastaanotto = Serialization.read[ClientSideVastaanotto](requestBody)
     try {
       if (valintatulosService.vastaanota(henkiloOid, hakemusOid, hakukohdeOid, clientVastaanotto.vastaanottoAction)) {


### PR DESCRIPTION
"Bugissa" oli kyse dataongelmasta, joka korjaantui jälkikäsittelemällä hakemus, ks. https://jira.oph.ware.fi/jira/browse/BUG-1737

Lisätään kuitenkin yksityiskohtaisempaa sovelluslogitusta vastaanottoon, jotta jatkossa on helpompi selvittää, mitä tapahtuu ja miksi vastaanotto on mahdollisesti epäonnistunut. Eli esimerkiksi, onko hakemuksen vastaanottaminen mahdotonta, vai eikö koko hakemusta ole löytynyt mongosta/atarusta, tai onko se löytynyt mutta väärillä oideilla.