### PR TITLE
BUG-1908 vastaanoton valinnan radiobuttonit bugaa

### DIFF
--- a/src/main/js/directives/hakutoiveenVastaanotto.html
+++ b/src/main/js/directives/hakutoiveenVastaanotto.html
@@ -20,14 +20,14 @@
       <ul class="hakutoive-options">
           <li>
             <label>
-              <input type="radio" name="vastaanotettavaHakutoive" value="VastaanotaSitovasti" ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()" ng-click="ctrl.flashSiirtohakuNotification()"/>
+              <input type="radio" name="vastaanotettavaHakutoive" value="VastaanotaSitovasti" ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()" ng-click="ctrl.flashSiirtohakuNotification(); ctrl.selectHakukohde(hakutoive.hakukohdeOid)" />
               {{ ctrl.haku().toisenasteenhaku ? localization('message.acceptEducation.acceptToinenAste') : localization('message.acceptEducation.accept') }}
             </label>
           </li>
           <li ng-show="hakutoive.vastaanotettavuustila == 'VASTAANOTETTAVISSA_EHDOLLISESTI'">
               <label>
               <input type="radio" name="vastaanotettavaHakutoive" value="VastaanotaEhdollisesti"
-                     ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()"/>
+                     ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()" ng-click="ctrl.selectHakukohde(hakutoive.hakukohdeOid)"/>
                 {{ localization('message.acceptEducation.conditionalAccept') }}
               </label>
               <ul class="info">
@@ -37,7 +37,7 @@
           </li>
           <li>
             <label>
-              <input type="radio" name="vastaanotettavaHakutoive" value="Peru" ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()"/>
+              <input type="radio" name="vastaanotettavaHakutoive" value="Peru" ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()" ng-click="ctrl.selectHakukohde(hakutoive.hakukohdeOid)"/>
               {{ localization('message.acceptEducation.reject') }}
             </label>
           </li>

--- a/src/main/js/directives/hakutoiveenVastaanotto.html
+++ b/src/main/js/directives/hakutoiveenVastaanotto.html
@@ -20,14 +20,14 @@
       <ul class="hakutoive-options">
           <li>
             <label>
-              <input type="radio" name="vastaanotettavaHakutoive" value="VastaanotaSitovasti" ng-model="ctrl.vastaanottoAction" ng-disabled="ctrl.isVastaanottoKesken()" ng-click="ctrl.flashSiirtohakuNotification()"/>
+              <input type="radio" name="vastaanotettavaHakutoive" value="VastaanotaSitovasti" ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()" ng-click="ctrl.flashSiirtohakuNotification()"/>
               {{ ctrl.haku().toisenasteenhaku ? localization('message.acceptEducation.acceptToinenAste') : localization('message.acceptEducation.accept') }}
             </label>
           </li>
           <li ng-show="hakutoive.vastaanotettavuustila == 'VASTAANOTETTAVISSA_EHDOLLISESTI'">
               <label>
               <input type="radio" name="vastaanotettavaHakutoive" value="VastaanotaEhdollisesti"
-                     ng-model="ctrl.vastaanottoAction" ng-disabled="ctrl.isVastaanottoKesken()"/>
+                     ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()"/>
                 {{ localization('message.acceptEducation.conditionalAccept') }}
               </label>
               <ul class="info">
@@ -37,11 +37,11 @@
           </li>
           <li>
             <label>
-              <input type="radio" name="vastaanotettavaHakutoive" value="Peru" ng-model="ctrl.vastaanottoAction" ng-disabled="ctrl.isVastaanottoKesken()"/>
+              <input type="radio" name="vastaanotettavaHakutoive" value="Peru" ng-model="ctrl.vastaanottoAction[hakutoive.hakukohdeOid]" ng-disabled="ctrl.isVastaanottoKesken()"/>
               {{ localization('message.acceptEducation.reject') }}
             </label>
           </li>
-          <li ng-if="ctrl.vastaanottoAction === 'Peru' && ctrl.isKkHaku()">
+          <li ng-if="ctrl.vastaanottoAction[hakutoive.hakukohdeOid] === 'Peru' && ctrl.isKkHaku()">
             <label>
               <input type="checkbox" name="confirmRejection" ng-model="ctrl.confirmCancelAction"/>
               {{ localization('message.acceptEducation.confirmReject') }}
@@ -53,7 +53,7 @@
           <span class="ajax-spinner" ng-show="ctrl.ajaxPending"></span>
           <button class="vastaanota-btn" disable-click-focus
                   ng-click="ctrl.vastaanotaHakutoive(hakutoive)"
-                  ng-disabled="ctrl.isNotVastaanotettavissa()"
+                  ng-disabled="ctrl.isNotVastaanotettavissa(hakutoive.hakukohdeOid)"
                   aria-label="{{ localization('button.vastaanota_ariaLabel') }}"
                   ng-bind="localization('button.vastaanota')">
           </button>

--- a/src/main/js/directives/hakutoiveenVastaanotto.js
+++ b/src/main/js/directives/hakutoiveenVastaanotto.js
@@ -52,10 +52,6 @@ class HakutoiveenVastaanottoController {
     return this.vastaanottoAction[hakukohdeOid] === 'Peru';
   }
 
-  isRejectSelected() {
-    return this.vastaanottoAction === 'Peru';
-  }
-
   isKkHaku() {
     return !this.haku().toisenasteenhaku;
   }

--- a/src/main/js/directives/hakutoiveenVastaanotto.js
+++ b/src/main/js/directives/hakutoiveenVastaanotto.js
@@ -24,6 +24,7 @@ class HakutoiveenVastaanottoController {
   constructor($timeout, restResources, $scope) {
     this.$timeout = $timeout;
     this.restResources = restResources;
+    this.selectedHakukohde = null;
 
     try {
       this.email = $scope.$parent.$parent.application.henkilotiedot['Sähköposti'].answer
@@ -42,6 +43,7 @@ class HakutoiveenVastaanottoController {
 
   isNotVastaanotettavissa(hakukohdeOid) {
     return !(this.vastaanottoAction && this.vastaanottoAction[hakukohdeOid] && this.vastaanottoAction[hakukohdeOid].length !== 0)
+      || (this.selectedHakukohde != hakukohdeOid)
       || this.isVastaanottoKesken()
       || (this.isRejectSelected(hakukohdeOid) && !this.confirmCancelAction && this.isKkHaku());
   }
@@ -62,6 +64,10 @@ class HakutoiveenVastaanottoController {
     this.siirtohakuClass = 'siirtohaku-fade-out';
     this.$timeout(() => this.siirtohakuClass = 'siirtohaku-fade-in', 50)
   };
+
+  selectHakukohde(hakukohdeOid) {
+    this.selectedHakukohde = hakukohdeOid;
+  }
 
   vastaanotaHakutoive(hakutoive) {
     this.ajaxPending = true;

--- a/src/main/js/directives/hakutoiveenVastaanotto.js
+++ b/src/main/js/directives/hakutoiveenVastaanotto.js
@@ -40,10 +40,14 @@ class HakutoiveenVastaanottoController {
     return this.ajaxPending || this.vastaanottoSentSuccessfully;
   };
 
-  isNotVastaanotettavissa() {
-    return !(this.vastaanottoAction && this.vastaanottoAction.length !== 0)
+  isNotVastaanotettavissa(hakukohdeOid) {
+    return !(this.vastaanottoAction && this.vastaanottoAction[hakukohdeOid] && this.vastaanottoAction[hakukohdeOid].length !== 0)
       || this.isVastaanottoKesken()
-      || (this.isRejectSelected() && !this.confirmCancelAction && this.isKkHaku());
+      || (this.isRejectSelected(hakukohdeOid) && !this.confirmCancelAction && this.isKkHaku());
+  }
+
+  isRejectSelected(hakukohdeOid) {
+    return this.vastaanottoAction[hakukohdeOid] === 'Peru';
   }
 
   isRejectSelected() {
@@ -68,7 +72,7 @@ class HakutoiveenVastaanottoController {
     };
 
     const data = {
-      vastaanottoAction: {action: this.vastaanottoAction},
+      vastaanottoAction: {action: this.vastaanottoAction[hakutoive.hakukohdeOid]},
       email: this.email,
       hakukohdeNimi: hakutoive.hakukohdeNimi,
       tarjoajaNimi: hakutoive.tarjoajaNimi

--- a/src/main/webapp/test/page/applicationListPage.js
+++ b/src/main/webapp/test/page/applicationListPage.js
@@ -303,6 +303,11 @@ function ApplicationListPage() {
             }
           },
 
+          selectedIndex: function() {
+              var checked = vastaanottoElement().find("[type=radio]:checked");
+              return checked.index()
+          },
+
           confirmButtonEnabled: function() {
             return !vastaanottoElement().find(".vastaanota-btn").prop("disabled")
           },

--- a/src/main/webapp/test/page/applicationListPage.js
+++ b/src/main/webapp/test/page/applicationListPage.js
@@ -298,7 +298,7 @@ function ApplicationListPage() {
 
           selectOption: function(id) {
             return function() {
-              vastaanottoElement().find("input[value='" + id + "']").click().click() // Angular hack
+              vastaanottoElement().find("input[value='" + id + "']").click()
               return wait.forAngular()
             }
           },

--- a/src/main/webapp/test/spec/applicationListSpec.js
+++ b/src/main/webapp/test/spec/applicationListSpec.js
@@ -847,9 +847,15 @@
             ])
           })
         })
-
-        describe("ensimmäisen paikan sitova vastaanottaminen", function() {
+        describe("ensimmäisen paikan sitovan vastaanottamisen valinta", function() {
           before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectOption("VastaanotaSitovasti"))
+          it("oikea nappi on valittuna", function () {
+            var selectedIndex = hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectedIndex();
+            expect(selectedIndex).to.equal(0)
+          })
+        })
+
+        describe("ensimmäisen paikan sitova vastaanottamisen lähetys", function() {
           before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).send)
 
           it("vastaanottotieto näkyy ja toinen paikka peruuntuu", function() {
@@ -890,9 +896,15 @@
             ])
           })
         })
-
-        describe("ensimmäisen paikan vastaanottaminen", function() {
+        describe("ensimmäisen paikan vastaanottamisen valinta", function() {
           before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectOption("VastaanotaSitovasti"))
+          it("oikea nappi on valittuna", function () {
+            var selectedIndex = hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).selectedIndex();
+            expect(selectedIndex).to.equal(0)
+          })
+        })
+
+        describe("ensimmäisen paikan vastaanottamisen lähetys", function() {
           before(hakemusYhteishakuKevat2013WithForeignBaseEducation.vastaanotto(0).send)
 
           describe("jälkeen", function() {


### PR DESCRIPTION
Kaikki vastaanotettavat hakutoiveet käyttivät samaa muuttujaa sille, onko valittuna Vastaanota/Peru. Tällöin valittu valintanappi (radio button) näkyi mielivaltaisella hakutoiveella. Lisäksi Lähetä vastaus -nappi oli aina aktivoituna kaikille hakutoiveille yhtä aikaa. Lähetä vastaus -nappi kuitenkin lähetti aina vastaanoton sille hakutoiveelle, jonka kohdalta sitä painettiin.

Testeissä oli häcki jossa vastaanoton valintanappia klikattiin kahdesti peräkkäin, mikä kiersi ongelman. Lisättiin nyt testi sille, että painettu valintanappi näkyy valittuna jo yhden klikkauksen jälkeen.

Lisättiin hakutoivekohtainen seuranta sille, mikä tila (Vastaanota/Peru) on valittuna. Lisäksi nyt vain viimeksi valitulla hakutoiveella näkyy valintanappi valittuna ja vain sille voi painaa Lähetä vastaus -nappia.