### PR TITLE
OY-300 bad request ja sessio deoptimisointi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   # This is needed for the maven-dependency-plugin to work to get valinta-tulos-service.war
   - sudo chown -R travis:travis $HOME/.m2
   - ./cibuild.bash
-  - export BASE_IMAGE="baseimage-fatjar:master"
+  - export BASE_IMAGE="baseimage-fatjar:OY-127-include-bc-prov-jar"
   - ./ci-tools/common/pull-image.sh
   - ./ci-tools/build/build-fatjar.sh $ARTIFACT_NAME
 

--- a/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/AuditLogUtils.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/AuditLogUtils.scala
@@ -7,7 +7,6 @@ import javax.servlet.http.HttpServletRequest
 import fi.vm.sade.utils.slf4j.Logging
 import org.ietf.jgss.Oid
 
-import scala.util.{Failure, Success, Try}
 import fi.vm.sade.javautils.http.HttpServletRequestUtils.getRemoteAddress
 import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionId
 

--- a/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/FetchTuloskirje.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/FetchTuloskirje.scala
@@ -1,7 +1,6 @@
 package fi.vm.sade.hakemuseditori.auditlog
 
-import fi.vm.sade.auditlog.{Changes, Target, User}
-import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionId
+import fi.vm.sade.auditlog.{Changes, Target}
 import javax.servlet.http.HttpServletRequest
 
 case class FetchTuloskirje(request: HttpServletRequest, hakuOid: String, hakemusOid: String) extends AuditLogUtils with AuditEvent {

--- a/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/SaveIlmoittautuminen.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/SaveIlmoittautuminen.scala
@@ -2,9 +2,8 @@ package fi.vm.sade.hakemuseditori.auditlog
 
 import javax.servlet.http.HttpServletRequest
 
-import fi.vm.sade.auditlog.{Changes, Target, User}
+import fi.vm.sade.auditlog.{Changes, Target}
 import fi.vm.sade.hakemuseditori.valintatulokset.domain.Ilmoittautuminen
-import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionId
 
 case class SaveIlmoittautuminen(request: HttpServletRequest, hakuOid: String, hakemusOid: String, ilmoittautuminen: Ilmoittautuminen, success: Boolean) extends AuditLogUtils with AuditEvent {
   override val operation: OmatSivutOperation = OmatSivutOperation.SAVE_ILMOITTAUTUMINEN

--- a/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/SaveVastaanotto.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/SaveVastaanotto.scala
@@ -1,8 +1,7 @@
 package fi.vm.sade.hakemuseditori.auditlog
 
-import fi.vm.sade.auditlog.{Changes, Target, User}
+import fi.vm.sade.auditlog.{Changes, Target}
 import fi.vm.sade.hakemuseditori.valintatulokset.domain.VastaanottoAction
-import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionId
 import javax.servlet.http.HttpServletRequest
 
 case class SaveVastaanotto(request: HttpServletRequest, userOid: String, hakemusOid: String, hakukohdeOid: String, hakuOid: String, vastaanotto: VastaanottoAction) extends AuditLogUtils with AuditEvent {

--- a/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/ShowHakemus.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/ShowHakemus.scala
@@ -1,7 +1,6 @@
 package fi.vm.sade.hakemuseditori.auditlog
 
-import fi.vm.sade.auditlog.{Changes, Target, User}
-import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionId
+import fi.vm.sade.auditlog.{Changes, Target}
 import javax.servlet.http.HttpServletRequest
 
 

--- a/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/ShowValidatedHakemus.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/ShowValidatedHakemus.scala
@@ -1,7 +1,6 @@
 package fi.vm.sade.hakemuseditori.auditlog
 
 import fi.vm.sade.auditlog.{Changes, Target, User}
-import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionId
 import javax.servlet.http.HttpServletRequest
 
 

--- a/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/UpdateHakemus.scala
+++ b/src/main/scala/fi/vm/sade/hakemuseditori/auditlog/UpdateHakemus.scala
@@ -1,8 +1,7 @@
 package fi.vm.sade.hakemuseditori.auditlog
 
-import fi.vm.sade.auditlog.{Changes, Target, User}
+import fi.vm.sade.auditlog.{Changes, Target}
 import fi.vm.sade.hakemuseditori.hakemus.domain.Hakemus.Answers
-import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionId
 import javax.servlet.http.HttpServletRequest
 
 case class UpdateHakemus(request: HttpServletRequest, userOid: String, hakemusOid: String, hakuOid: String, originalAnswers: Answers, updatedAnswers: Answers) extends AuditLogUtils with AuditEvent {

--- a/src/main/scala/fi/vm/sade/omatsivut/auditlog/Login.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/auditlog/Login.scala
@@ -4,8 +4,9 @@ import javax.servlet.http.HttpServletRequest
 import fi.vm.sade.auditlog.{Changes, Target, User}
 import fi.vm.sade.hakemuseditori.auditlog.{AuditEvent, AuditLogUtils, OmatSivutMessageField, OmatSivutOperation}
 import fi.vm.sade.omatsivut.security.SessionInfoRetriever.{getOppijaNumero, getSessionId}
+import fi.vm.sade.omatsivut.security.SessionService
 
-case class Login(request: HttpServletRequest) extends AuditLogUtils with AuditEvent {
+case class Login(request: HttpServletRequest)(implicit sessionService: SessionService) extends AuditLogUtils with AuditEvent {
   override val operation: OmatSivutOperation = OmatSivutOperation.LOGIN
   override val changes: Changes = new Changes.Builder().build()
   override val target: Target = {

--- a/src/main/scala/fi/vm/sade/omatsivut/auditlog/Logout.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/auditlog/Logout.scala
@@ -3,10 +3,10 @@ package fi.vm.sade.omatsivut.auditlog
 import javax.servlet.http.HttpServletRequest
 import fi.vm.sade.auditlog.{Changes, Target, User}
 import fi.vm.sade.hakemuseditori.auditlog.{AuditEvent, AuditLogUtils, OmatSivutMessageField, OmatSivutOperation}
-import fi.vm.sade.omatsivut.security.OppijaNumero
+import fi.vm.sade.omatsivut.security.{OppijaNumero, SessionService}
 import fi.vm.sade.omatsivut.security.SessionInfoRetriever._
 
-case class Logout(request: HttpServletRequest) extends AuditLogUtils with AuditEvent {
+case class Logout(request: HttpServletRequest)(implicit sessionService: SessionService) extends AuditLogUtils with AuditEvent {
   override val operation: OmatSivutOperation = OmatSivutOperation.LOGOUT
   override val changes: Changes = new Changes.Builder().build()
   override val target: Target = {

--- a/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
@@ -147,7 +147,7 @@ class ComponentRegistry(val config: AppConfig)
   lazy val omatsivutDb = new OmatsivutDb(config.settings.omatsivutDbConfig,
                                          config.isInstanceOf[IT],
                                          config.settings.sessionTimeoutSeconds.getOrElse(3600))
-  lazy val sessionService = new SessionService(omatsivutDb)
+  lazy implicit val sessionService = new SessionService(omatsivutDb)
   lazy val authenticationInfoService = configureAuthenticationInfoService
 
   def muistilistaService(language: Language): MuistilistaService = new MuistilistaService(language)
@@ -160,8 +160,8 @@ class ComponentRegistry(val config: AppConfig)
   def newSecuredSessionServlet = new SecuredSessionServlet(authenticationInfoService,
                                                            sessionService,
                                                            config.settings.sessionTimeoutSeconds)
-  def newSessionServlet = new SessionServlet(sessionService)
-  def newLogoutServlet = new LogoutServlet(sessionService)
+  def newSessionServlet = new SessionServlet()
+  def newLogoutServlet = new LogoutServlet()
   def newFixtureServlet = new FixtureServlet(config)
   def newKoodistoServlet = new KoodistoServlet
   def newMuistilistaServlet = new MuistilistaServlet(config)

--- a/src/main/scala/fi/vm/sade/omatsivut/security/AttributeNames.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/security/AttributeNames.scala
@@ -2,5 +2,4 @@ package fi.vm.sade.omatsivut.security
 
 trait AttributeNames {
   def sessionCookieName = "session"
-  def sessionInfoAttributeName = "sessionInfo"
 }

--- a/src/main/scala/fi/vm/sade/omatsivut/security/AuthenticationRequiringServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/security/AuthenticationRequiringServlet.scala
@@ -31,15 +31,10 @@ trait AuthenticationRequiringServlet extends OmatSivutServletBase with Logging {
           logger.info("Session has no oppijaNumero, should not find anything")
           halt(NotFound(render("error" -> "no oid was present")))
         }
-        session.setAttribute(sessionInfoAttributeName, sessionInfo)
+        pass()
       case _ =>
         logger.info("Session not found, fail the API request")
         halt(Unauthorized(render("error" -> "unauthorized")))
     }
-  }
-
-  after() {
-    // clean the http session, to avoid sessioninfo hanging in session object and maybe misleading somebody
-    session.removeAttribute(sessionInfoAttributeName)
   }
 }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilter.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilter.scala
@@ -27,16 +27,10 @@ class AuthenticateIfNoSessionFilter(val sessionService: SessionService)
     sessionService.getSession(sessionId) match {
       case Right(sessionInfo) =>
         logger.debug("Found session: " + sessionInfo.oppijaNumero)
-        session.setAttribute(sessionInfoAttributeName, sessionInfo)
+        pass()
       case _ =>
         logger.debug("Session not found, redirect to login")
         response.redirect(loginPath(request.getContextPath))
     }
   }
-
-  after() {
-    // clean the http session, to avoid sessioninfo hanging in session object and maybe misleading somebody
-    session.removeAttribute(sessionInfoAttributeName)
-  }
-
 }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/session/LogoutServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/session/LogoutServlet.scala
@@ -12,7 +12,7 @@ import org.scalatra.servlet.RichResponse
 
 trait LogoutServletContainer {
 
-  class LogoutServlet(val sessionService: SessionService) extends OmatSivutServletBase with AttributeNames {
+  class LogoutServlet(implicit val sessionService: SessionService) extends OmatSivutServletBase with AttributeNames {
     get("/*") {
       sessionService.deleteSession(cookies.get(sessionCookieName).map(UUID.fromString).map(SessionId))
       clearCookie(sessionCookieName)

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SecuredSessionServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SecuredSessionServlet.scala
@@ -1,19 +1,17 @@
 package fi.vm.sade.omatsivut.servlet.session
 
 import java.nio.charset.Charset
-import java.util.UUID
 
 import fi.vm.sade.hakemuseditori.auditlog.Audit
 import fi.vm.sade.omatsivut.auditlog.Login
 import fi.vm.sade.omatsivut.security._
 import fi.vm.sade.omatsivut.servlet.OmatSivutServletBase
 import fi.vm.sade.utils.slf4j.Logging
-import org.joda.time.LocalDate
-import org.scalatra.{BadRequest, Cookie, CookieOptions, InternalServerError}
+import org.scalatra.{BadRequest, Cookie, CookieOptions}
 
 trait SecuredSessionServletContainer {
   class SecuredSessionServlet(val authenticationInfoService: AuthenticationInfoService,
-                              val sessionService: SessionService,
+                              implicit val sessionService: SessionService,
                               val sessionTimeout: Option[Int] = None)
     extends OmatSivutServletBase with AttributeNames with OmatsivutPaths with Logging {
 

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SecuredSessionServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SecuredSessionServlet.scala
@@ -54,7 +54,7 @@ trait SecuredSessionServletContainer {
 
     private def redirectUri: String = {
       val link = omatsivutPath(request.getContextPath) + paramOption("redirect").getOrElse("/index.html")
-      logger.info("Link to forward to, after a session is established: " + link)
+      logger.debug("Link to forward to, after a session is established: " + link)
       link
     }
 

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SessionServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SessionServlet.scala
@@ -11,7 +11,7 @@ import fi.vm.sade.omatsivut.security.{AttributeNames, AuthenticationRequiringSer
 import fi.vm.sade.omatsivut.security.SessionInfoRetriever.getSessionInfo
 import org.json4s.Formats
 
-class SessionServlet(val sessionService: SessionService)
+class SessionServlet(implicit val sessionService: SessionService)
   extends OmatSivutServletBase
     with AuthenticationRequiringServlet with AttributeNames with JacksonJsonSupport with JsonFormats{
   private val formatter: DateTimeFormatter = DateTimeFormat.forPattern("ddMMYY")

--- a/src/test/scala/fi/vm/sade/omatsivut/security/AuthenticationRequiringServletSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/security/AuthenticationRequiringServletSpec.scala
@@ -40,9 +40,14 @@ class AuthenticationRequiringServletSpec extends MutableScalatraSpec with Mockit
   "AuthenticationRequiringServlet" should {
 
     "return authorization error if not authenticated" in {
-      val evo = 4
       get(testUrl) {
         status must_== 401
+      }
+    }
+
+    "return bad request (400) if session cookie is not a correct UUID" in {
+      get(testUrl, headers = CookieHelper.cookieHeaderWith(sessionCookieName -> "NOT-AN-UUID")) {
+        status must_== 400
       }
     }
 

--- a/src/test/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilterSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilterSpec.scala
@@ -22,14 +22,11 @@ class AuthenticateIfNoSessionFilterSpec extends MutableScalatraSpec with Mockito
   val sessionRepository: SessionRepository = mock[SessionRepository]
   val sessionService = new SessionService(sessionRepository)
   val authenticateIfNoSessionFilter = new AuthenticateIfNoSessionFilter(sessionService)
-  var sessionInfoFromSession: Option[SessionInfo] = None
 
   addFilter(authenticateIfNoSessionFilter, "/*")
 
   val dummyServlet = new ScalatraServlet {
     get(originalUrl) {
-      val sessionInfo = request.getSession().getAttribute("sessionInfo").asInstanceOf[SessionInfo]
-      sessionInfoFromSession = if (sessionInfo != null) Some(sessionInfo) else None
       Ok("ok")
     }
   }
@@ -39,8 +36,7 @@ class AuthenticateIfNoSessionFilterSpec extends MutableScalatraSpec with Mockito
 
   "AuthenticateIfNoSessionFilter" should {
 
-    "redirect to login if session does not exist in cookie" in {
-      sessionRepository.get(id) returns Left(SessionFailure.SESSION_NOT_FOUND)
+    "redirect to login if session does not exist in cookie" in new NoSessionInDatabase {
       get("omatsivut" + originalUrl) {
         status must_== 302
         val location = response.headers("Location")(0)
@@ -48,8 +44,7 @@ class AuthenticateIfNoSessionFilterSpec extends MutableScalatraSpec with Mockito
       }
     }
 
-    "redirect to login if correctly formatted session exists in cookie, but not in repository" in {
-      sessionRepository.get(id) returns Left(SessionFailure.SESSION_NOT_FOUND)
+    "redirect to login if correctly formatted session exists in cookie, but not in repository" in new NoSessionInDatabase {
       get(originalUrl, headers = CookieHelper.cookieHeaderWith("session" -> id.value.toString)) {
         status must_== 302
       }
@@ -61,17 +56,18 @@ class AuthenticateIfNoSessionFilterSpec extends MutableScalatraSpec with Mockito
       }
     }
 
-    "pass if session exists in cookie and in repository, and create a copy in http request's session" in new WithTestSession {
-      sessionInfoFromSession = None
+    "pass if session exists in cookie and in repository" in new WithTestSession {
       get(originalUrl, headers = CookieHelper.cookieHeaderWith("session" -> id.value.toString)) {
         status must_== 200
-        sessionInfoFromSession must_!= None
-        sessionInfoFromSession.map(_.hetu) must_== Some(hetu)
       }
     }
   }
 
-  trait WithTestSession extends Scope with MustThrownExpectations {
+  trait NoSessionInDatabase extends Scope {
+    sessionRepository.get(id) returns Left(SessionFailure.SESSION_NOT_FOUND)
+  }
+
+  trait WithTestSession extends Scope {
     val hetu = Hetu("123456-789A")
     val oppijaNumero = OppijaNumero("1.2.3.4.5.6")
     val oppijaNimi = "John Smith"

--- a/src/test/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilterSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilterSpec.scala
@@ -48,10 +48,16 @@ class AuthenticateIfNoSessionFilterSpec extends MutableScalatraSpec with Mockito
       }
     }
 
-    "redirect to login if session exists in cookie but not in repository" in {
+    "redirect to login if correctly formatted session exists in cookie, but not in repository" in {
       sessionRepository.get(id) returns Left(SessionFailure.SESSION_NOT_FOUND)
       get(originalUrl, headers = CookieHelper.cookieHeaderWith("session" -> id.value.toString)) {
         status must_== 302
+      }
+    }
+
+    "return BadRequest (400) if session exists in cookie, but is not a correct UUID" in {
+      get(originalUrl, headers = CookieHelper.cookieHeaderWith("session" -> "NOT-AN-UUID")) {
+        status must_== 400
       }
     }
 


### PR DESCRIPTION
These are improvements on top of OY-127: 

- [x] return BadRequest (400) when session cookie is present but is not a well formatted UUID (this affects both API and UI requests) 

- [x] stop using Scalatra sessions. It turned out that the database reads for SessionInfo are so
lightweight that there is no point in trying to optimize by keeping
SessionInfo in memory within scalatra session field "sessionInfo".
With this change, we are replacing the use of scalatra sessions with
direct read from database (SessionInfoRetriever). It means that for many
requests, there will be two session lookups in database, but it is ok,
because database will in most cases read the data from some sort of cache
memory, and will not require any additional UI operation.