### PR TITLE
BUG-2022 : Fix redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7130,6 +7130,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
       "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
     },
+    "moment-timezone": {
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
+      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
+      "requires": {
+        "moment": "2.22.1"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
         <repository>
             <id>ScalazBintrayRepo</id>
             <name>Scalaz Bintray Repo</name>
-            <url>http://dl.bintray.com/scalaz/releases/</url>
+            <url>https://dl.bintray.com/scalaz/releases/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilter.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/AuthenticateIfNoSessionFilter.scala
@@ -30,7 +30,7 @@ class AuthenticateIfNoSessionFilter(val sessionService: SessionService)
         pass()
       case _ =>
         logger.debug("Session not found, redirect to login")
-        response.redirect(loginPath(request.getContextPath))
+        redirect(loginPath(request.getContextPath))
     }
   }
 }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/MuistilistaServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/MuistilistaServlet.scala
@@ -25,7 +25,7 @@ trait MuistilistaServletContainer {
       val compressedMuistilista = params("compressedMuistilista")
       val asString = UrlValueCompressor.decompress(compressedMuistilista)
       response.addCookie(Cookie("basket", URLEncoder.encode(asString, "UTF-8"))(CookieOptions(path = "/")))
-      response.redirect(OphUrlProperties.url("koulutusinformaatio-app.muistilista"))
+      redirect(OphUrlProperties.url("koulutusinformaatio-app.muistilista"))
     }
 
     post() {

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/session/LoginServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/session/LoginServlet.scala
@@ -4,6 +4,6 @@ import fi.vm.sade.omatsivut.servlet.{OmatSivutServletBase}
 
 class LoginServlet() extends OmatSivutServletBase with OmatsivutPaths {
   get("/*") {
-    response.redirect(loginPath(request.getContextPath))
+    redirect(loginPath(request.getContextPath))
   }
 }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/session/LogoutServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/session/LogoutServlet.scala
@@ -41,7 +41,7 @@ trait LogoutServletContainer {
         "/oma-opintopolku"
       else
         "/koski/user/logout"
-      response.redirect(OphUrlProperties.url("shibboleth.logout", returnUrl))
+      redirect(OphUrlProperties.url("shibboleth.logout", returnUrl))(request, response.res)
     }
   }
 }

--- a/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SecuredSessionServlet.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/servlet/session/SecuredSessionServlet.scala
@@ -41,7 +41,7 @@ trait SecuredSessionServletContainer {
           response.addCookie(Cookie(sessionCookieName, sessionId.value.toString)
             (CookieOptions(domain = "", secure = isHttps, path = "/", maxAge = sessionTimeout.getOrElse(3600), httpOnly = true)))
           Audit.oppija.log(Login(request))
-          response.redirect(redirectUri)
+          redirect(redirectUri)
         case Left(e) =>
           logger.error("Unable to create session. (" + e + ")")
           halt(500, "unable to create session, exception = " + e)


### PR DESCRIPTION
Redirecting like this produces HTTP 302 instead of HTTP 500 responses from omatsivut, and gets rid of these stack traces in the application log:

```
2019-06-27T15:11:23.257+03 WARN  {} [qtp1706292388-30] WARN  org.eclipse.jetty.server.HttpChannel: /omatsivut/index.html
java.lang.IllegalStateException: STREAM
	at org.eclipse.jetty.server.Response.getWriter(Response.java:931)
	at org.scalatra.ScalatraBase$class.renderUncaughtException(ScalatraBase.scala:229)
```