### PR TITLE
OY-299 scheduled deletion of expired sessions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <name>fi.vm.sade</name>
     </organization>
     <properties>
-        <valinta-tulos-service.version>5.0.1-SNAPSHOT</valinta-tulos-service.version>
+        <valinta-tulos-service.version>5.0.2-SNAPSHOT</valinta-tulos-service.version>
         <jetty.version>9.4.15.v20190215</jetty.version>
         <postgresql.version>42.2.5</postgresql.version>
         <scalatra.version>2.5.1</scalatra.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.vm.sade</groupId>
     <artifactId>omatsivut</artifactId>
-    <version>15.0-SNAPSHOT</version>
+    <version>16.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>omatsivut</description>
     <name>omatsivut</name>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
             <version>1.2.3</version>
         </dependency>
         <dependency>
+            <groupId>com.github.kagkarlsson</groupId>
+            <artifactId>db-scheduler</artifactId>
+            <version>5.2</version>
+        </dependency>
+        <dependency>
             <groupId>fi.vm.sade.haku</groupId>
             <artifactId>hakemus-api</artifactId>
             <version>15.4-SNAPSHOT</version>

--- a/src/main/resources/db/migration/V2__add_table_for_db-scheduler.sql
+++ b/src/main/resources/db/migration/V2__add_table_for_db-scheduler.sql
@@ -1,0 +1,16 @@
+/* based on https://github.com/kagkarlsson/db-scheduler/blob/master/src/test/resources/postgresql_tables.sql */
+
+create table scheduled_tasks (
+    task_name text not null,
+    task_instance text not null,
+    task_data bytea,
+    execution_time timestamp with time zone not null,
+    picked BOOLEAN not null,
+    picked_by text,
+    last_success timestamp with time zone,
+    last_failure timestamp with time zone,
+    consecutive_failures INT,
+    last_heartbeat timestamp with time zone,
+    version BIGINT not null,
+    PRIMARY KEY (task_name, task_instance)
+)

--- a/src/main/resources/db/migration/V2__add_table_for_db-scheduler.sql
+++ b/src/main/resources/db/migration/V2__add_table_for_db-scheduler.sql
@@ -1,5 +1,5 @@
 /* based on https://github.com/kagkarlsson/db-scheduler/blob/master/src/test/resources/postgresql_tables.sql */
-
+drop table if exists scheduled_tasks;
 create table scheduled_tasks (
     task_name text not null,
     task_instance text not null,

--- a/src/main/resources/oph-configuration/common.properties.template
+++ b/src/main/resources/oph-configuration/common.properties.template
@@ -62,6 +62,7 @@ omatsivut.db.registerMbeans=true
 omatsivut.db.initializationFailTimeout=1000
 
 omatsivut.sessionTimeoutSeconds={{ omatsivut_session_timeout | default("3600")}}
+omatsivut.sessionCleanupCronString={{ omatsivut_session_cleanup_cron | default("0 10 0 * * ?") }}
 
 protocol_ataru_hakija: {{protocol_ataru_hakija}}
 host_ataru_hakija: {{host_ataru_hakija}}

--- a/src/main/scala/fi/vm/sade/omatsivut/config/AppConfig.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/config/AppConfig.scala
@@ -53,14 +53,27 @@ object AppConfig extends Logging {
   }
 
   class Dev extends AppConfig with ExampleTemplatedProps with MockAuthentication with StubbedExternalDeps {
+    val localPostgresService = new LocalPostgresService
+
     def springConfiguration = new OmatSivutSpringContext.Dev()
 
     override lazy val settings = ConfigTemplateProcessor.createSettings("common", templateAttributesFile)
       .withOverride("mongodb.oppija.uri", "mongodb://localhost:27017")
+      .withOverride("omatsivut.db.port", itPostgresPortChooser.chosenPort.toString)
+      .withOverride("omatsivut.db.host", "localhost")
+      .withOverride("omatsivut.db.url", "jdbc:postgresql://localhost:" + itPostgresPortChooser.chosenPort + "/omatsivutdb")
+
+    override def onStart: Unit = {
+      localPostgresService.start()
+    }
+
+    override def onStop: Unit = {
+      localPostgresService.stop()
+    }
   }
 
   class IT extends AppConfig with ExampleTemplatedProps with MockAuthentication with StubbedExternalDeps {
-    def springConfiguration = new OmatSivutSpringContext.Dev()
+    def springConfiguration: OmatSivutConfiguration = new OmatSivutSpringContext.Dev()
 
     // Testien vaatimat overridet
     OphUrlProperties.addOverride("url-oppija", "http://localhost:" + AppConfig.embeddedJettyPortChooser.chosenPort.toString)

--- a/src/main/scala/fi/vm/sade/omatsivut/config/AppConfig.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/config/AppConfig.scala
@@ -142,7 +142,7 @@ object AppConfig extends Logging {
   }
 
   class LocalPostgresService extends LocalService {
-    private lazy val itPostgres = new ITPostgres(itPostgresPortChooser)
+    private val itPostgres = new ITPostgres(itPostgresPortChooser)
 
     override def start() {
       itPostgres.start()

--- a/src/main/scala/fi/vm/sade/omatsivut/config/ApplicationSettings.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/config/ApplicationSettings.scala
@@ -29,6 +29,7 @@ case class ApplicationSettings(config: Config) extends GroupEmailerSettings(conf
   )
 
   val sessionTimeoutSeconds = getInt(config, "omatsivut.sessionTimeoutSeconds")
+  val sessionCleanupCronString = getString(config, "omatsivut.sessionCleanupCronString")
 
   val aesKey : String = config.getString("omatsivut.crypto.aes.key")
   val hmacKey : String = config.getString("omatsivut.crypto.hmac.key")

--- a/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
@@ -156,7 +156,7 @@ class ComponentRegistry(val config: AppConfig)
   private def configureScheduler() = {
     val numberOfThreads: Int = 1
     val scheduledTasks = List(
-      SessionCleaner.createTaskForScheduler(sessionService, config.settings.sessionCleanupCronString.getOrElse("0 10 0 * * ? *"))
+      SessionCleaner.createTaskForScheduler(sessionService, config.settings.sessionCleanupCronString.getOrElse("0 10 0 * * ?"))
     )
     val scheduler: Scheduler = Scheduler.create(omatsivutDb.dataSource).startTasks(scheduledTasks.asJava).threads(numberOfThreads).build
     logger.info(s"Starting scheduler with ${scheduledTasks.length} task(s)")

--- a/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
@@ -159,6 +159,7 @@ class ComponentRegistry(val config: AppConfig)
       SessionCleaner.createTaskForScheduler(sessionService, config.settings.sessionCleanupCronString.getOrElse("0 10 0 * * ? *"))
     )
     val scheduler: Scheduler = Scheduler.create(omatsivutDb.dataSource).startTasks(scheduledTasks.asJava).threads(numberOfThreads).build
+    logger.info(s"Starting scheduler with ${scheduledTasks.length} task(s)")
     scheduler.start()
   }
 

--- a/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/config/ComponentRegistry.scala
@@ -1,5 +1,6 @@
 package fi.vm.sade.omatsivut.config
 
+import com.github.kagkarlsson.scheduler.Scheduler
 import fi.vm.sade.ataru.{AtaruService, AtaruServiceComponent}
 import fi.vm.sade.groupemailer.{GroupEmailComponent, GroupEmailService}
 import fi.vm.sade.hakemuseditori.domain.Language.Language
@@ -28,6 +29,8 @@ import fi.vm.sade.omatsivut.servlet._
 import fi.vm.sade.omatsivut.servlet.session.{LogoutServletContainer, SecuredSessionServletContainer, SessionServlet}
 import fi.vm.sade.omatsivut.vastaanotto.VastaanottoComponent
 import fi.vm.sade.utils.captcha.CaptchaServiceComponent
+
+import scala.collection.JavaConverters._
 
 class ComponentRegistry(val config: AppConfig)
   extends SpringContextComponent with
@@ -149,6 +152,17 @@ class ComponentRegistry(val config: AppConfig)
                                          config.settings.sessionTimeoutSeconds.getOrElse(3600))
   lazy implicit val sessionService = new SessionService(omatsivutDb)
   lazy val authenticationInfoService = configureAuthenticationInfoService
+
+  private def configureScheduler() = {
+    val numberOfThreads: Int = 1
+    val scheduledTasks = List(
+      SessionCleaner.createTaskForScheduler(sessionService, config.settings.sessionCleanupCronString.getOrElse("0 10 0 * * ? *"))
+    )
+    val scheduler: Scheduler = Scheduler.create(omatsivutDb.dataSource).startTasks(scheduledTasks.asJava).threads(numberOfThreads).build
+    scheduler.start()
+  }
+
+  val scheduler = configureScheduler()
 
   def muistilistaService(language: Language): MuistilistaService = new MuistilistaService(language)
   def vastaanottoService(implicit language: Language): VastaanottoService = new VastaanottoService()

--- a/src/main/scala/fi/vm/sade/omatsivut/db/SessionRepository.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/db/SessionRepository.scala
@@ -8,4 +8,5 @@ trait SessionRepository {
   def store(session: SessionInfo): SessionId
   def get(id: SessionId): Either[SessionFailure, SessionInfo]
   def delete(id: SessionId): Unit
+  def deleteExpired(): Int
 }

--- a/src/main/scala/fi/vm/sade/omatsivut/db/impl/OmatsivutDb.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/db/impl/OmatsivutDb.scala
@@ -36,7 +36,10 @@ class OmatsivutDb(config: DbConfig, itProfile: Boolean = false, override val ses
     c.setLeakDetectionThreshold(config.leakDetectionThresholdMillis.getOrElse(c.getMaxLifetime))
     c
   }
-  override val dataSource = new HikariDataSource(hikariConfig)
+  override val dataSource = {
+    new HikariDataSource(hikariConfig)
+  }
+
   override val db = {
     val maxConnections = config.numThreads.getOrElse(10)
     val executor = AsyncExecutor("omatsivut",

--- a/src/main/scala/fi/vm/sade/omatsivut/db/impl/OmatsivutRepository.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/db/impl/OmatsivutRepository.scala
@@ -5,6 +5,7 @@ import java.util.ConcurrentModificationException
 import java.util.concurrent.TimeUnit
 
 import fi.vm.sade.utils.slf4j.Logging
+import javax.sql.DataSource
 import org.postgresql.util.PSQLException
 import org.springframework.util.ReflectionUtils
 import slick.dbio._
@@ -22,6 +23,7 @@ trait OmatsivutRepository extends Logging {
   private val logSqlOfSomeQueries = false // For debugging only. Do NOT enable in production.
 
   val db: Database
+  val dataSource: DataSource
   def runBlocking[R](operations: DBIO[R], timeout: Duration = Duration(10, TimeUnit.MINUTES)): R = {  // TODO put these 3–4 different default timeouts behind common, configurable value
     if (logSqlOfSomeQueries) {
       logger.error("This should not happen in production.")

--- a/src/main/scala/fi/vm/sade/omatsivut/security/SessionCleaner.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/security/SessionCleaner.scala
@@ -1,0 +1,45 @@
+package fi.vm.sade.omatsivut.security
+
+import java.time.Instant
+
+import com.github.kagkarlsson.scheduler.task.{DeadExecutionHandler, Execution, ExecutionComplete, ExecutionContext, ExecutionOperations, TaskInstance, VoidExecutionHandler}
+import com.github.kagkarlsson.scheduler.task.helper.{RecurringTask, Tasks}
+import com.github.kagkarlsson.scheduler.task.schedule.{CronSchedule, Schedule}
+import fi.vm.sade.utils.slf4j.Logging
+
+object SessionCleaner extends Logging {
+
+  def createTaskForScheduler(sessionService: SessionService, cronString: String) = {
+
+    val executionHandler: VoidExecutionHandler[Void] = new VoidExecutionHandler[Void] {
+      logger.info("Scheduled task execution handler setup")
+
+      override def execute(taskInstance: TaskInstance[Void], executionContext: ExecutionContext): Unit = {
+        logger.info("Scheduled session cleanup starting")
+        sessionService.deleteAllExpired()
+        logger.info("Scheduled session cleanup finished")
+      }
+    }
+
+    class DeadExecutionRescheduler(schedule: Schedule) extends DeadExecutionHandler[Void] {
+      logger.info(s"Dead execution handler setup for schedule $schedule")
+      override def deadExecution(execution: Execution, executionOperations: ExecutionOperations[Void]): Unit = {
+        val now = Instant.now
+        val complete = ExecutionComplete.failure(execution, now, now, null)
+        val next: Instant = schedule.getNextExecutionTime(complete)
+        logger.warn("Rescheduling dead execution: " + execution + " to " + next)
+        executionOperations.reschedule(complete, next)
+      }
+    }
+
+    val cronSchedule: Schedule = new CronSchedule(cronString)
+    val deadExecutionRescheduler = new DeadExecutionRescheduler(cronSchedule)
+
+    logger.info(s"Session clean up, scheduled task created (cron=$cronString)")
+
+    Tasks.recurring(s"cron-session-cleaner-task", cronSchedule)
+      .onDeadExecution(deadExecutionRescheduler)
+      .execute(executionHandler)
+  }
+
+}

--- a/src/main/scala/fi/vm/sade/omatsivut/security/SessionCleaner.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/security/SessionCleaner.scala
@@ -35,7 +35,7 @@ object SessionCleaner extends Logging {
     val cronSchedule: Schedule = new CronSchedule(cronString)
     val deadExecutionRescheduler = new DeadExecutionRescheduler(cronSchedule)
 
-    logger.info(s"Session clean up, scheduled task created (cron=$cronString)")
+    logger.info(s"Session cleanup, scheduled task created (cron=$cronString)")
 
     Tasks.recurring(s"cron-session-cleaner-task", cronSchedule)
       .onDeadExecution(deadExecutionRescheduler)

--- a/src/main/scala/fi/vm/sade/omatsivut/security/SessionCleaner.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/security/SessionCleaner.scala
@@ -9,7 +9,7 @@ import fi.vm.sade.utils.slf4j.Logging
 
 object SessionCleaner extends Logging {
 
-  def createTaskForScheduler(sessionService: SessionService, cronString: String) = {
+  def createTaskForScheduler(sessionService: SessionService, cronString: String): RecurringTask[Void] = {
 
     val executionHandler: VoidExecutionHandler[Void] = new VoidExecutionHandler[Void] {
       logger.info("Scheduled task execution handler setup")

--- a/src/main/scala/fi/vm/sade/omatsivut/security/SessionService.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/security/SessionService.scala
@@ -13,9 +13,16 @@ class SessionService(val sessionRepository: SessionRepository) extends Logging {
     case None => logger.debug("no sessionId given")
     case Some(id) => {
       Try(sessionRepository.delete(id)) match {
-        case Success(_) => logger.debug("session " + id + " removed from database")
-        case Failure(t) => logger.error("Did not manage to remove session " + id + " from database", t)
+        case Success(_) => logger.debug("Session " + id + " removed from database")
+        case Failure(t) => logger.error("Failed to remove session " + id + " from database", t)
       }
+    }
+  }
+
+  def deleteAllExpired(): Unit = {
+    Try(sessionRepository.deleteExpired()) match {
+      case Success(count) => logger.info("Deleted " + count + " expired sessions from database")
+      case Failure(t) => logger.error("Failed to delete expired sessions from database", t)
     }
   }
 

--- a/src/test/scala/fi/vm/sade/omatsivut/ITSetup.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/ITSetup.scala
@@ -6,12 +6,11 @@ import slick.jdbc.{GetResult, PositionedParameters, SetParameter}
 
 trait ITSetup {
   implicit val appConfig = new AppConfig.IT
+  appConfig.onStart()
   val dbConfig = appConfig.settings.omatsivutDbConfig
   val testSessionTimeout: Int = 100
 
-  lazy val singleConnectionOmatsivutDb = new OmatsivutDb(
+  val singleConnectionOmatsivutDb = new OmatsivutDb(
     dbConfig.copy(maxConnections = Some(1), minConnections = Some(1), numThreads = Some(1)),
     sessionTimeoutSeconds = testSessionTimeout)
-
-  lazy val omatsivutDbWithPool = new OmatsivutDb(dbConfig, true, sessionTimeoutSeconds = testSessionTimeout)
 }

--- a/src/test/scala/fi/vm/sade/omatsivut/TestProfile.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/TestProfile.scala
@@ -9,8 +9,8 @@ import org.apache.commons.io.FileUtils
 object SharedAppConfig {
   lazy final val appConfig = new AppConfig.IT
   lazy val componentRegistry: ComponentRegistry = {
+    appConfig.onStart()
     val registry = new ComponentRegistry(appConfig)
-    registry.start()
     registry
   }
 }

--- a/src/test/scala/fi/vm/sade/omatsivut/config/AppConfigSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/config/AppConfigSpec.scala
@@ -2,6 +2,7 @@ package fi.vm.sade.omatsivut.config
 
 import fi.vm.sade.omatsivut.{ITSetup, OmatsivutDbTools, config}
 import fi.vm.sade.omatsivut.config.AppConfig.AppConfig
+import fi.vm.sade.utils.config.ConfigTemplateProcessor
 import org.junit.runner.RunWith
 import org.specs2.matcher.PathMatchers
 import org.specs2.mutable.Specification
@@ -16,7 +17,7 @@ class AppConfigSpec extends Specification with ITSetup with OmatsivutDbTools {
 
   "Config with default profile" should {
     "Start up" in {
-      validateConfig(new AppConfig with AppConfig.ExampleTemplatedProps {
+      validateConfig(new AppConfig.IT {
         override def springConfiguration = new OmatSivutSpringContext.Default()
       })
     }

--- a/src/test/scala/fi/vm/sade/omatsivut/db/OmatsivutDbSessionSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/db/OmatsivutDbSessionSpec.scala
@@ -5,9 +5,8 @@ import java.util.UUID
 import fi.vm.sade.omatsivut.SessionFailure.SessionFailure
 import fi.vm.sade.omatsivut.security.{Hetu, OppijaNumero, SessionId, SessionInfo}
 import fi.vm.sade.omatsivut.{ITSetup, OmatsivutDbTools, SessionFailure}
-import javax.security.sasl.AuthenticationException
 import org.junit.runner.RunWith
-import org.specs2.matcher.MustThrownExpectations
+import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.Scope
@@ -31,26 +30,76 @@ class OmatsivutDbSessionSpec extends Specification with ITSetup with OmatsivutDb
     }
 
     "not find a stored session if timeout has expired" in new OneSessionInDatabase {
-      val session = singleConnectionOmatsivutDb.get(id)
+      val sessionBeforeExpiration = singleConnectionOmatsivutDb.get(id)
       setSessionLastAccessTime(id.value.toString, testSessionTimeout + 1)
-      val sessionObsolete = singleConnectionOmatsivutDb.get(id)
-      session must beRight(SessionInfo(hetu, oppijaNumero, oppijaNimi));
-      sessionObsolete must beLeft(SessionFailure.SESSION_EXPIRED)
+      val sessionAfterExpiration = singleConnectionOmatsivutDb.get(id)
+      sessionBeforeExpiration must beRight(SessionInfo(hetu, oppijaNumero, oppijaNimi));
+      sessionAfterExpiration must beLeft(SessionFailure.SESSION_EXPIRED)
+    }
+
+    "delete all expired sessions does not delete anything if there is no expired sessions" in new ThreeSessionsInDatabase {
+      setSessionLastAccessTime(id1.value.toString, testSessionTimeout - 1)
+      setSessionLastAccessTime(id2.value.toString, testSessionTimeout - 5)
+      setSessionLastAccessTime(id3.value.toString, testSessionTimeout - 100)
+
+      val deletedCount = singleConnectionOmatsivutDb.deleteExpired()
+
+      deletedCount must beEqualTo(0)
+      verifySessionIsInDatabase(id1)
+      verifySessionIsInDatabase(id2)
+      verifySessionIsInDatabase(id3)
+    }
+
+    "delete all expired sessions" in new ThreeSessionsInDatabase {
+      setSessionLastAccessTime(id1.value.toString, testSessionTimeout + 1)
+      setSessionLastAccessTime(id2.value.toString, testSessionTimeout + 10000)
+      setSessionLastAccessTime(id3.value.toString, testSessionTimeout - 1)
+
+      val deletedCount = singleConnectionOmatsivutDb.deleteExpired()
+
+      deletedCount must beEqualTo(2)
+      verifySessionIsNotFoundInDatabase(id1)
+      verifySessionIsNotFoundInDatabase(id2)
+      verifySessionIsInDatabase(id3)
     }
 
     "delete a stored session by id" in new OneSessionInDatabase {
       singleConnectionOmatsivutDb.delete(id)
-      val session = singleConnectionOmatsivutDb.get(id)
-      session must beLeft(SessionFailure.SESSION_NOT_FOUND)
+      verifySessionIsNotFoundInDatabase(id)
     }
   }
 
   step(deleteAllSessions())
 
-  trait OneSessionInDatabase extends Scope with MustThrownExpectations {
+  trait OneSessionInDatabase extends Scope with CommonsAndNonKeySessionData {
+    val id = createSessionAndVerifyItIsThere()
+  }
+
+  trait ThreeSessionsInDatabase extends Scope with CommonsAndNonKeySessionData {
+    val id1 = createSessionAndVerifyItIsThere()
+    val id2 = createSessionAndVerifyItIsThere()
+    val id3 = createSessionAndVerifyItIsThere()
+  }
+
+  trait CommonsAndNonKeySessionData {
     val hetu = Hetu("123456-789A")
     val oppijaNumero = OppijaNumero("1.2.3.4.5.6")
     val oppijaNimi = "John Smith"
-    val id = singleConnectionOmatsivutDb.store(SessionInfo(hetu, oppijaNumero, oppijaNimi))
+
+    def createSessionAndVerifyItIsThere(): SessionId = {
+      val id: SessionId = singleConnectionOmatsivutDb.store(SessionInfo(hetu, oppijaNumero, oppijaNimi))
+      verifySessionIsInDatabase(id)
+      id
+    }
+
+    def verifySessionIsInDatabase(id: SessionId) = {
+      val existingSession = singleConnectionOmatsivutDb.get(id)
+      existingSession must beRight(SessionInfo(hetu, oppijaNumero, oppijaNimi))
+    }
+
+    def verifySessionIsNotFoundInDatabase(id: SessionId): MatchResult[Either[SessionFailure, SessionInfo]] = {
+      val nonExistingSession = singleConnectionOmatsivutDb.get(id)
+      nonExistingSession must beLeft(SessionFailure.SESSION_NOT_FOUND)
+    }
   }
 }

--- a/src/test/scala/fi/vm/sade/omatsivut/security/SessionCleanerSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/security/SessionCleanerSpec.scala
@@ -13,11 +13,14 @@ class SessionCleanerSpec extends Specification {
 
   "SessionCleaner task" should {
 
-    "is constructed" in new SessionCleanerWithMocks {
-      task must_!= null
+    "is not constructed if cron string is not correct" in new MockSessionService {
+      SessionCleaner.createTaskForScheduler(sessionService, "0 15 0 *") must throwA[IllegalArgumentException].like {
+        case e => e.getMessage must contain("contains 4 parts but we expect one of [6]")
+      }
     }
 
-    "when executed will invoke the deleteAllExpired method" in new SessionCleanerWithMocks {
+    "when executed will invoke the deleteAllExpired method" in new MockSessionService {
+      val task = SessionCleaner.createTaskForScheduler(sessionService, "0 15 0 * * ?")
 
       task.execute(null, null)
 
@@ -25,8 +28,7 @@ class SessionCleanerSpec extends Specification {
     }
   }
 
-  trait SessionCleanerWithMocks extends Mockito with Scope with MustThrownExpectations {
+  trait MockSessionService extends Mockito with Scope with MustThrownExpectations {
     val sessionService: SessionService = mock[SessionService]
-    val task = SessionCleaner.createTaskForScheduler(sessionService, "0 15 0 * * ?")
   }
 }

--- a/src/test/scala/fi/vm/sade/omatsivut/security/SessionCleanerSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/security/SessionCleanerSpec.scala
@@ -1,0 +1,32 @@
+package fi.vm.sade.omatsivut.security
+
+import org.junit.runner.RunWith
+import org.specs2.matcher.MustThrownExpectations
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.Scope
+
+
+@RunWith(classOf[JUnitRunner])
+class SessionCleanerSpec extends Specification {
+
+  "SessionCleaner task" should {
+
+    "is constructed" in new SessionCleanerWithMocks {
+      task must_!= null
+    }
+
+    "when executed will invoke the deleteAllExpired method" in new SessionCleanerWithMocks {
+
+      task.execute(null, null)
+
+      there was one(sessionService).deleteAllExpired()
+    }
+  }
+
+  trait SessionCleanerWithMocks extends Mockito with Scope with MustThrownExpectations {
+    val sessionService: SessionService = mock[SessionService]
+    val task = SessionCleaner.createTaskForScheduler(sessionService, "0 15 0 * * ?")
+  }
+}

--- a/src/test/scala/fi/vm/sade/omatsivut/security/SessionServiceSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/security/SessionServiceSpec.scala
@@ -51,9 +51,13 @@ class SessionServiceSpec extends Specification with MockitoStubs {
     }
 
     "deleteSession will delete a session from repository" in new SessionServiceWithMocks {
-      sessionRepository.get(id) returns Left(SessionFailure.SESSION_NOT_FOUND)
       sessionService.deleteSession(Some(id))
       there was one(sessionRepository).delete(id)
+    }
+
+    "deleteAllExpiredSessions will delete expired sessions" in new SessionServiceWithMocks {
+      sessionService.deleteAllExpired()
+      there was one(sessionRepository).deleteExpired()
     }
   }
 


### PR DESCRIPTION
`SessionRepository` expanded with method to delete all expired sessions. 

`db-scheduler` is used to schedule job. It needs a table in the database, and takes care of locking so that the task is executed only once, regardless of the number of instances

`db-scheduler` needs the DataSource, because of that, it was necessary to change the way postgres database is initialized. Before database schema creation was relying on lazy initialization to happen only after the database is up and running. Now that `db-scheduler` needed DataSource, the schema creation had to happen earlier, and the implementation had to be modified to explicitly startup the database before creating schema (using flywaydb)