### PR TITLE
Satunnaisia testifeiluja: SecuredSessionServletSpec , LogoutServletSpec

### DIFF
--- a/src/main/scala/fi/vm/sade/omatsivut/security/fake/FakeAuthentication.scala
+++ b/src/main/scala/fi/vm/sade/omatsivut/security/fake/FakeAuthentication.scala
@@ -1,11 +1,10 @@
 package fi.vm.sade.omatsivut.security.fake
 
-import fi.vm.sade.omatsivut.security.AttributeNames
-import javax.servlet.http.{Cookie, HttpServletRequest}
+import fi.vm.sade.omatsivut.security.{AttributeNames, SessionId}
 
 object FakeAuthentication extends AttributeNames {
 
-  def authHeaders[A](oid: String, sessionId: String): Map[String, String] = {
-    Map("Cookie" -> (sessionCookieName + "=" + sessionId))
+  def authHeaders[A](oid: String, sessionId: SessionId): Map[String, String] = {
+    Map("Cookie" -> (sessionCookieName + "=" + sessionId.value.toString))
   }
 }

--- a/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
@@ -17,10 +17,10 @@ trait OmatsivutDbTools extends Specification {
 
   val singleConnectionOmatsivutDb: OmatsivutDb
 
-  def createTestSession()(implicit personOid: PersonOid): String = {
+  def createTestSession()(implicit personOid: PersonOid): SessionId = {
     val dummyHetu = Hetu("121212-789A")
     val dummyName = "John Smith"
-    singleConnectionOmatsivutDb.store(SessionInfo(dummyHetu, OppijaNumero(personOid.oid), dummyName)).value.toString
+    singleConnectionOmatsivutDb.store(SessionInfo(dummyHetu, OppijaNumero(personOid.oid), dummyName))
   }
 
   def setSessionLastAccessTime(sessionIdString: String, howManySecondsFromNow: Int): Unit = {
@@ -31,15 +31,16 @@ trait OmatsivutDbTools extends Specification {
     ).transactionally, Duration(20, TimeUnit.SECONDS))
   }
 
-  def getPersonFromSession(sessionIdString: String): Option[String] = {
-    val sessionId = SessionId(UUID.fromString(sessionIdString))
+  def getPersonFromSession(sessionId: String): Option[String] = getPersonFromSession(SessionId(UUID.fromString(sessionId)))
+
+  def getPersonFromSession(sessionId: SessionId): Option[String] = {
     logger.info(s"sessionId: $sessionId")
     singleConnectionOmatsivutDb.get(sessionId) match {
       case x@Right(SessionInfo(_, oppijaNumero, _)) =>
         logger.info(s"Found from db: $x")
         Some(oppijaNumero.value)
       case x =>
-        logger.info(s"Problem when getting session $sessionIdString from db: got $x")
+        logger.info(s"Problem when getting session $sessionId from db: got $x")
         None
     }
   }

--- a/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
@@ -23,7 +23,7 @@ trait OmatsivutDbTools extends Specification {
     singleConnectionOmatsivutDb.store(SessionInfo(dummyHetu, OppijaNumero(personOid.oid), dummyName)).value.toString
   }
 
-  def setSessionLastAccessTime(sessionIdString: String, howManySecondsFromNow: Int) = {
+  def setSessionLastAccessTime(sessionIdString: String, howManySecondsFromNow: Int): Unit = {
     singleConnectionOmatsivutDb.runBlocking(DBIO.seq(
       sqlu"""update sessions
                         set viimeksi_luettu = now() - interval '#${howManySecondsFromNow} seconds'

--- a/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
@@ -33,14 +33,13 @@ trait OmatsivutDbTools extends Specification {
 
   def getPersonFromSession(sessionIdString: String): Option[String] = {
     val sessionId = SessionId(UUID.fromString(sessionIdString))
-    logger.info(s"sessionIdString: $sessionIdString")
     logger.info(s"sessionId: $sessionId")
     singleConnectionOmatsivutDb.get(sessionId) match {
       case x@Right(SessionInfo(_, oppijaNumero, _)) =>
         logger.info(s"Found from db: $x")
         Some(oppijaNumero.value)
       case x =>
-        logger.info(s"Problem when getting session from db: got $x")
+        logger.info(s"Problem when getting session $sessionIdString from db: got $x")
         None
     }
   }

--- a/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/OmatsivutDbTools.scala
@@ -36,7 +36,7 @@ trait OmatsivutDbTools extends Specification {
     logger.info(s"sessionIdString: $sessionIdString")
     logger.info(s"sessionId: $sessionId")
     singleConnectionOmatsivutDb.get(sessionId) match {
-      case x@Right(SessionInfo(hetu, oppijaNumero, oppijaNimi)) =>
+      case x@Right(SessionInfo(_, oppijaNumero, _)) =>
         logger.info(s"Found from db: $x")
         Some(oppijaNumero.value)
       case x =>
@@ -48,7 +48,7 @@ trait OmatsivutDbTools extends Specification {
   def getDisplayNameFromSession(sessionIdString: String): Option[String] = {
     val sessionId = SessionId(UUID.fromString(sessionIdString))
     singleConnectionOmatsivutDb.get(sessionId) match {
-      case Right(SessionInfo(hetu, oppijaNumero, oppijaNimi)) => Some(oppijaNimi)
+      case Right(SessionInfo(_, _, oppijaNimi)) => Some(oppijaNimi)
       case _ => None
     }
   }

--- a/src/test/scala/fi/vm/sade/omatsivut/ScalatraTestSupport.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/ScalatraTestSupport.scala
@@ -1,11 +1,11 @@
 package fi.vm.sade.omatsivut
 
-import java.net.HttpCookie
+import java.util.UUID
 
 import fi.vm.sade.hakemuseditori.hakemus.HakemusSpringContext
 import fi.vm.sade.omatsivut.config.AppConfig
-import fi.vm.sade.omatsivut.security.CookieHelper
 import fi.vm.sade.omatsivut.security.fake.FakeAuthentication
+import fi.vm.sade.omatsivut.security.{CookieHelper, SessionId}
 import org.scalatra.test.{ClientResponse, HttpComponentsClient}
 import org.specs2.mutable.Specification
 
@@ -13,7 +13,7 @@ trait ScalatraTestSupport extends Specification with HttpComponentsClient with O
 
   protected lazy val springContext: HakemusSpringContext = SharedAppConfig.componentRegistry.springContext
 
-  var lastSessionId: String = ""
+  var lastSessionId: SessionId = SessionId(UUID.randomUUID())
 
   step {
     SharedJetty.start

--- a/src/test/scala/fi/vm/sade/omatsivut/ScalatraTestSupport.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/ScalatraTestSupport.scala
@@ -20,7 +20,7 @@ trait ScalatraTestSupport extends Specification with HttpComponentsClient with O
     springContext
   }
 
-  def baseUrl = "http://localhost:" + AppConfig.embeddedJettyPortChooser.chosenPort + "/omatsivut"
+  def baseUrl: String = "http://localhost:" + AppConfig.embeddedJettyPortChooser.chosenPort + "/omatsivut"
 
   def authGet[A](uri: String)(f: => A)(implicit personOid: PersonOid): A = {
     val sessionId = createTestSession()

--- a/src/test/scala/fi/vm/sade/omatsivut/ScalatraTestSupport.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/ScalatraTestSupport.scala
@@ -47,7 +47,10 @@ trait ScalatraTestSupport extends Specification with HttpComponentsClient with O
 
 trait ScalatraTestCookiesSupport {
   def cookieGetValue(response: ClientResponse, cookieName: String): Option[String] = {
-    response.headers("Set-Cookie").map(CookieHelper.cookieExtractValue(_, cookieName)).find(v => v.isDefined && v.get.length > 0).getOrElse(None)
+    response.headers("Set-Cookie").
+      map(CookieHelper.cookieExtractValue(_, cookieName)).
+      find(v => v.isDefined && v.get.length > 0).
+      flatten
   }
 }
 

--- a/src/test/scala/fi/vm/sade/omatsivut/servlet/LogoutServletSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/servlet/LogoutServletSpec.scala
@@ -1,6 +1,6 @@
 package fi.vm.sade.omatsivut.servlet
 
-import fi.vm.sade.omatsivut.security.{AttributeNames, SessionId, OppijaNumero}
+import fi.vm.sade.omatsivut.security.AttributeNames
 import fi.vm.sade.omatsivut.{PersonOid, ScalatraTestCookiesSupport, ScalatraTestSupport}
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
@@ -13,21 +13,21 @@ class LogoutServletSpec extends ScalatraTestSupport with AttributeNames with Sca
   "logout" should {
 
     "clear the session and oppijaNumero cookies and deletes the session from repository, redirect to oma-opintopolku" in {
-      authGet("logout?koski=true") {
+      authGetAndReturnSession("logout?koski=true") { sessionId =>
         status must_== 302
         val location = response.headers("Location")(0)
         location must endWith("Shibboleth.sso/Logout?return=%2Foma-opintopolku")
-        getPersonFromSession(lastSessionId) must beNone
+        getPersonFromSession(sessionId) must beNone
         cookieGetValue(response, sessionCookieName) must beNone
       }
     }
 
     "redirect to koski logout if koski parameter is not given" in {
-      authGet("logout") {
+      authGetAndReturnSession("logout") { sessionId =>
         status must_== 302
         val location = response.headers("Location")(0)
         location must endWith("Shibboleth.sso/Logout?return=%2Fkoski%2Fuser%2Flogout")
-        getPersonFromSession(lastSessionId) must beNone
+        getPersonFromSession(sessionId) must beNone
         cookieGetValue(response, sessionCookieName) must beNone
       }
     }

--- a/src/test/scala/fi/vm/sade/omatsivut/servlet/SecuredSessionServletSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/servlet/SecuredSessionServletSpec.scala
@@ -4,11 +4,13 @@ import fi.vm.sade.omatsivut.fixtures.TestFixture
 import fi.vm.sade.omatsivut.security.AttributeNames
 import fi.vm.sade.omatsivut.{ScalatraTestCookiesSupport, ScalatraTestSupport}
 import org.junit.runner.RunWith
+import org.slf4j.LoggerFactory
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class SecuredSessionServletSpec extends ScalatraTestSupport with AttributeNames with ScalatraTestCookiesSupport {
   val urlUsedByShibboleth = "initsession"
+  private val logger = LoggerFactory.getLogger(getClass)
 
   "GET /initsession" should {
     "fails with bad request (400) if request does not contain henkilötunnus" in {
@@ -26,6 +28,10 @@ class SecuredSessionServletSpec extends ScalatraTestSupport with AttributeNames 
         location must endWith("omatsivut/index.html")
         val sessionId = cookieGetValue(response, sessionCookieName).getOrElse("not found session cookie")
         val personOid = getPersonFromSession(sessionId).getOrElse("not found in repository")
+        logger.info(s"response: $response")
+        logger.info(s"location: $location")
+        logger.info(s"sessionId: $sessionId")
+        logger.info(s"personOid: $personOid")
         personOid must_== TestFixture.personOid
       }
     }

--- a/src/test/scala/fi/vm/sade/omatsivut/servlet/SecuredSessionServletSpec.scala
+++ b/src/test/scala/fi/vm/sade/omatsivut/servlet/SecuredSessionServletSpec.scala
@@ -1,10 +1,8 @@
 package fi.vm.sade.omatsivut.servlet
 
-import java.util.UUID
-
-import fi.vm.sade.omatsivut.{ScalatraTestCookiesSupport, ScalatraTestSupport}
 import fi.vm.sade.omatsivut.fixtures.TestFixture
-import fi.vm.sade.omatsivut.security.{AttributeNames}
+import fi.vm.sade.omatsivut.security.AttributeNames
+import fi.vm.sade.omatsivut.{ScalatraTestCookiesSupport, ScalatraTestSupport}
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
@@ -21,10 +19,10 @@ class SecuredSessionServletSpec extends ScalatraTestSupport with AttributeNames 
     }
 
     "create a session in repository and forwards to root if the request contains hetu header" in {
-      deleteAllSessions
+      deleteAllSessions()
       get(urlUsedByShibboleth, headers = Map("hetu" -> TestFixture.testHetu)) {
         status must_== 302
-        val location = response.headers("Location")(0)
+        val location = response.headers("Location").head
         location must endWith("omatsivut/index.html")
         val sessionId = cookieGetValue(response, sessionCookieName).getOrElse("not found session cookie")
         val personOid = getPersonFromSession(sessionId).getOrElse("not found in repository")
@@ -33,10 +31,10 @@ class SecuredSessionServletSpec extends ScalatraTestSupport with AttributeNames 
     }
 
     "create a session with no oid if hetu does not have the corresponding oid" in {
-      deleteAllSessions
+      deleteAllSessions()
       get(urlUsedByShibboleth, headers = Map("hetu" -> TestFixture.testHetuWithNoPersonOid)) {
         status must_== 302
-        val location = response.headers("Location")(0)
+        val location = response.headers("Location").head
         location must endWith("omatsivut/index.html")
         val sessionId = cookieGetValue(response, sessionCookieName).getOrElse("not found session cookie")
         val personOid = getPersonFromSession(sessionId).getOrElse("not found in repository")
@@ -45,7 +43,7 @@ class SecuredSessionServletSpec extends ScalatraTestSupport with AttributeNames 
     }
 
     "create a session in repository, and it will contain also the display name of the user" in {
-      deleteAllSessions
+      deleteAllSessions()
       val firstName = "Wolfgang"
       val secondName = "Mozart"
       get(urlUsedByShibboleth, headers = Map("hetu" -> TestFixture.testHetu, "firstname" -> firstName, "sn" -> secondName)) {


### PR DESCRIPTION
Pari testiä feilasi satunnaisesti race conditionien takia:

* SecuredSessionServletSpecin metodit deletoivat kaikki sessiot kannasta eikä vain testin käyttämää
* LogoutServletSpec välitti session id:n jaetun muuttujan kautta

Muutoksia on vain testikoodissa (ja FakeAuthentication.scala :ssa).